### PR TITLE
Add: curve extension methods - IsPointOnCurve

### DIFF
--- a/GeometryExtensions/CurveExtension.cs
+++ b/GeometryExtensions/CurveExtension.cs
@@ -1,0 +1,30 @@
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
+
+namespace Gile.AutoCAD.Geometry
+{
+    /// <summary>
+    /// Provides extension methods for the Curve type.
+    /// </summary>
+    public static class CurveExtension
+    {
+        /// <summary>
+        /// Checks if the point is within the distance Tolerance.EqualPoint from this curve.
+        /// </summary>
+        /// <param name="curve">The instance of Curve to which this method applies.</param>
+        /// <param name="point">Point to check against.</param>
+        /// <param name="tolerance">Tolerance value.</param>
+        /// <returns>true, if the condition is met; otherwise, false.</returns>
+        public static bool IsPointOnCurve(this Curve curve, Point3d point, Tolerance tolerance) =>
+            point.IsEqualTo(curve.GetClosestPointTo(point, false), tolerance);
+
+        /// <summary>
+        /// Calls curve.IsPointOnCurve(Point3d point, Tolerance tolerance) with tolerance set to Global.
+        /// </summary>
+        /// <param name="curve">The instance of Curve to which this method applies.</param>
+        /// <param name="point"Point to check against.</param>
+        /// <returns>true, if the condition is met; otherwise, false.</returns>
+        public static bool IsPointOnCurve(this Curve curve, Point3d point) =>
+            curve.IsPointOnCurve(point, Tolerance.Global);
+    }
+}


### PR DESCRIPTION
Adapted from Kean Walmsley's code.

A handy method that would be available on all subclasses of `Curve`. 

I would add that it creates a dependency on: 

```c#
using Autodesk.AutoCAD.DatabaseServices
```

That may / may not be something you are keen on.