### PR TITLE
add: convenience methods to allow for easy addition to the collection

### DIFF
--- a/GeometryExtensions/PolylineSegmentCollection.cs
+++ b/GeometryExtensions/PolylineSegmentCollection.cs
@@ -56,6 +56,11 @@ namespace Gile.AutoCAD.Geometry
         /// <param name="pline">An instance of Polyline.</param>
         public PolylineSegmentCollection(Polyline pline)
         {
+            addPolyline(pline);
+        }
+
+        private void addPolyline(Polyline pline)
+        {
             int n = pline.NumberOfVertices - 1;
             for (int i = 0; i < n; i++)
             {
@@ -378,6 +383,27 @@ namespace Gile.AutoCAD.Geometry
                 pline.Closed = true;
             }
             return pline;
+        }
+
+        /// <summary>
+        /// Add a single polyline
+        /// </summary>
+        /// <param name="polyline"></param>
+        public void Add(Polyline polyline)
+        {
+            addPolyline(polyline);
+        }
+
+        /// <summary>
+        /// Add a collection of polylines.
+        /// </summary>
+        /// <param name="polylines"></param>
+        public void AddRange(IEnumerable<Polyline> polylines)
+        {
+            foreach (Polyline polyline in polylines)
+            {
+                addPolyline(polyline);
+            }
         }
 
         #endregion


### PR DESCRIPTION
### What is this PR?

Adds convenience methods - i.e. "conceptual compression" for the developer:

### Before:
```c#
PolylineSegmentCollection psg = new PolylineSegmentCollection();
psg.AddRange(new PolylineSegmentCollection(polyline1));
psg.AddRange(new PolylineSegmentCollection(polyline2)); // too much to remember
```

### After:
```c#
PolylineSegmentCollection psg = new PolylineSegmentCollection();
psg.Add(polyline1);  // just wanna add the polyline, and let the library take care of the details.
psg.Add(polyline2);
```

Or we can add a whole list full of polylines:
```c#
PolylineSegmentCollection psg = new PolylineSegmentCollection();
List<Polyline> polylines = new List<Polyline>(){ polyline1, polyline2}
psg.AddRange(polylines );
```

Then it's a matter of joining them:
```c#
foreach (PolylineSegmentCollection seg in psg.Join())
{
      seg.ToPolyline(); // add to model space
 }
```

I'm using the above approach, but I think it's worth incorporating into your library.


### Side note
As a side note, I suppose it's also possible to do the following - and it might be worth it, but I personally do not have this use case (yet):

```c#
PolylineSegmentCollection psg = new PolylineSegmentCollection();
List<Entity> entities= new List<Entity>(){ ... etc }
psg.AddRange(entities, plane)

// And then, within the AddRange method, we could handle all the complexity accordingly.
// I have seen a similar approach you've used in the swamp forums but I lost the link.
// i think it would make it conceptually similar for the developer to add a range, and with a plane for example
// and not worry about case statements from the calling class/object - that complexity might be best
// handled within the GeometryExtensions library itself.
// this is just a side note and an idea.
```
I would be interested to hear your thoughts.
