### PR TITLE
Add: curves functionality

### DIFF
--- a/GeometryExtensions/ArcExtension.cs
+++ b/GeometryExtensions/ArcExtension.cs
@@ -1,0 +1,37 @@
+﻿using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gile.AutoCAD.Geometry
+{
+    public static class ArcExtension
+    {
+        /// <summary>
+        /// Converts an Arc into a CircularArc2d given a plane.
+        /// </summary>
+        /// <param name="arc"></param>
+        /// <param name="plane"></param>
+        /// <returns></returns>
+        public static CircularArc2d ToCircularArc2d(this Arc arc, Plane plane = null)
+        {
+            if (plane == null)
+            {
+                plane = new Plane(new Point3d(), Vector3d.ZAxis);
+            }            
+
+            Point2d startPoint = arc.StartPoint.Convert2d(plane);
+
+            Point2d intermediatePoint  = arc.GetPointAtDist(arc.Length / 2.0)
+                                            .Convert2d(plane);            
+
+            Point2d endPoint = arc.EndPoint.Convert2d(plane);
+
+            CircularArc2d circularArc2D = new CircularArc2d(startPoint, intermediatePoint, endPoint);
+            return circularArc2D;
+        }
+    }
+}

--- a/GeometryExtensions/CurveExtension.cs
+++ b/GeometryExtensions/CurveExtension.cs
@@ -1,5 +1,6 @@
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Geometry;
+using Autodesk.AutoCAD.Runtime;
 
 namespace Gile.AutoCAD.Geometry
 {
@@ -24,7 +25,34 @@ namespace Gile.AutoCAD.Geometry
         /// <param name="curve">The instance of Curve to which this method applies.</param>
         /// <param name="point">Point to check against.</param>
         /// <returns>true, if the condition is met; otherwise, false.</returns>
+        
         public static bool IsPointOnCurve(this Curve curve, Point3d point) =>
             curve.IsPointOnCurve(point, Tolerance.Global);
+        
+        public static bool IsArc(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Arc));
+        public static bool IsCircle(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Circle));
+        public static bool IsEllipse(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Ellipse));
+        
+        public static bool IsLeader(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Leader));
+        public static bool IsLine(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Line));
+
+        public static bool IsPolyline(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Polyline));
+        public static bool IsPolyline2d(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Polyline2d));
+        public static bool IsPolyline3d(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Polyline3d));
+        public static bool IsRay(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Ray));
+        public static bool IsSpline(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Spline));
+        public static bool IsXline(this Curve curve) =>
+            curve.GetRXClass() == RXObject.GetClass(typeof(Xline));
+
     }
 }

--- a/GeometryExtensions/Polyline3dExtension.cs
+++ b/GeometryExtensions/Polyline3dExtension.cs
@@ -1,5 +1,8 @@
 ﻿using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Geometry;
+using System.Collections.Generic;
+
+using AcRx = Autodesk.AutoCAD.Runtime;
 
 namespace Gile.AutoCAD.Geometry
 {
@@ -31,5 +34,25 @@ namespace Gile.AutoCAD.Geometry
         /// <returns>The projected Polyline.</returns>
         public static Polyline GetOrthoProjectedPolyline(this Polyline3d pline, Plane plane) =>
             pline.GetProjectedPolyline(plane, plane.Normal);
+
+        /// <summary>
+        /// Gets all the Vertex3d elements for a given polyline3d
+        /// </summary>
+        /// <param name="pline"></param>
+        /// <returns></returns>
+        public static List<PolylineVertex3d> GetVertices(this Polyline3d pline)
+        {
+            Transaction tr = pline.Database.TransactionManager.TopTransaction;
+            if (tr == null)
+                throw new AcRx.Exception(AcRx.ErrorStatus.NoActiveTransactions);
+
+            List<PolylineVertex3d> vertices = new List<PolylineVertex3d>();
+            foreach (ObjectId id in pline)
+            {
+                PolylineVertex3d vx = (PolylineVertex3d)tr.GetObject(id, OpenMode.ForRead);
+                vertices.Add(vx);
+            }
+            return vertices;
+        }
     }
 }


### PR DESCRIPTION
Hi Gilles,

I recently had a use case where I had to add many different types into a PolylineSegmentCollection.

I made the changes to your library so it could run with my client code. 

Hence this PR.

```c#
PolylineSegmentCollection psg = new PolylineSegmentCollection();
List<Curve> curves = new List<Curve>(){ ... etc };
psg.AddRangeFilteredCurves(curves, plane);
```

The problem is that the Curve class also encompasses Splines, XLines, Rays etc, which doesn't make much sense as a PolylineSegmentCollection - so I changed the name to `AddRangeFilteredCurves` rather than `AddRange`.

LMK if these proposals are completely ridiculous.


rgds
Ben




