### PR TITLE
fix: distance comparison in GetNeighbour method of KdTree

### DIFF
--- a/GeometryExtensionsR19/KdTree.cs
+++ b/GeometryExtensionsR19/KdTree.cs
@@ -183,7 +183,7 @@ namespace Gile.AutoCAD.R19.Geometry
                 bestDist = dist;
             }
             dist = coordCen - coordCur;
-            if (bestDist < dist * dist)
+            if (bestDist < dist )
             {
                 if (coordCen < coordCur)
                 {

--- a/GeometryExtensionsR25/KdTree.cs
+++ b/GeometryExtensionsR25/KdTree.cs
@@ -170,7 +170,7 @@ namespace Gile.AutoCAD.R25.Geometry
                 bestDist = dist;
             }
             dist = coordCen - coordCur;
-            if (bestDist < dist * dist)
+            if (bestDist < dist )
             {
                 currentBest = GetNeighbour(
                     center, coordCen < coordCur ? node.LeftChild : node.RightChild, currentBest, bestDist);


### PR DESCRIPTION
Best distance is compared with squared distance (i.e. dist^2)... Comparison must be done with like terms (either both must be squared or both must not be squared).

I detected this issue because it was your GetNeighbour was not returning the actual nearest neighbour for a block in my drawing.